### PR TITLE
Fix bluetooth scanning

### DIFF
--- a/Application/src/main/java/tw/qtlin/mac/airunlocker/BLEService.java
+++ b/Application/src/main/java/tw/qtlin/mac/airunlocker/BLEService.java
@@ -330,7 +330,7 @@ public class BLEService extends Service
                 mBluetoothLeScanner.startScan(mLeFilter,
                         new ScanSettings.Builder().
                                 setScanMode(ScanSettings.SCAN_MODE_LOW_POWER).
-                                setCallbackType(ScanSettings.CALLBACK_TYPE_FIRST_MATCH).
+                                setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES).
                                 build(),
                         mDeviceScanCallback);
             }


### PR DESCRIPTION
This should fix: https://github.com/pinetum/AirUnlock-for-Mac/issues/3

It worked for me, Ulefone Future, Android 6.0.1